### PR TITLE
Remove ModuleFreeIva from RP-1 avionics

### DIFF
--- a/GameData/FreeIva/Patches/RP-0.cfg
+++ b/GameData/FreeIva/Patches/RP-0.cfg
@@ -1,0 +1,4 @@
+@PART[RP0probe*,RP0aerobee*]:HAS[@MODULE[ModuleFreeIva]]:AFTER[RP-0]
+{
+	!MODULE[ModuleFreeIva] { }
+}


### PR DESCRIPTION
Because the stock asasmodule1-2 is cloned to be used as RP-1 sounding rocket avionics the already patched-in ModuleFreeIva is in there.

This is removed again.
